### PR TITLE
🐛 Umami visitor fallback

### DIFF
--- a/app/api/visitors/route.ts
+++ b/app/api/visitors/route.ts
@@ -28,8 +28,13 @@ export async function GET(req: Request) {
     return NextResponse.json({ views: previous });
   }
 
-  const views = await getVisitorCount(path);
-  cache.set(path, { value: views, expires: now + TTL });
+  try {
+    const views = await getVisitorCount(path);
+    cache.set(path, { value: views, expires: now + TTL });
 
-  return NextResponse.json({ views });
+    return NextResponse.json({ views });
+  } catch (error) {
+    console.error('Failed to fetch visitor count:', error);
+    return NextResponse.json({ views: 0 });
+  }
 }

--- a/app/notes/[slug]/page.tsx
+++ b/app/notes/[slug]/page.tsx
@@ -79,10 +79,6 @@ export default async function Note({
                 day: 'numeric',
               })}
             </p>
-            <span className="text-title-small-strong text-foreground-neutral-subtle">
-              ·
-            </span>
-            <ViewCounter path={`/notes/${slug}`} />
           </div>
         </div>
         <div className="flex flex-col gap-2">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,3 @@
-import { AnimatedCounter } from '@/components/animated-counter';
 import { Container } from '@/components/container';
 import { Greeting } from '@/components/greeting';
 import { MovingArrow } from '@/components/moving-arrow';
@@ -9,7 +8,6 @@ import { WaveSine } from '@/components/wave-sine';
 import { home as meta } from '@/data/metadata';
 import { work } from '@/data/work';
 import { fetchDatabaseContent } from '@/lib/notion';
-import { getTotalUniqueVisitors } from '@/lib/umami';
 import {
   extractFaviconFromUrl,
   formatDate,
@@ -60,14 +58,7 @@ export default async function Home() {
         </Transition>
         <Transition delay={0.3}>
           <p className="text-foreground-neutral-faded">
-            Welcome to my corner of the internet. You are visitor{' '}
-            <AnimatedCounter
-              from={0}
-              to={await getTotalUniqueVisitors()}
-              duration={0.8}
-              delay={0.4}
-              className="text-foreground-neutral-default font-semibold"
-            />
+            Welcome to my corner of the internet.
           </p>
         </Transition>
       </div>


### PR DESCRIPTION
## Summary
- Remove the homepage visitor counter that called Umami's paid API for total unique visitors
- Remove per-note view counters that depended on the `/api/visitors` endpoint
- Gracefully return `{ views: 0 }` from the visitors API when Umami is unreachable or unauthorized

## Test plan
- [x] Homepage loads without the "You are visitor N" counter
- [x] Note pages render without view counts in the header
- [x] `/api/visitors?path=/notes/example` returns `{ views: 0 }` when Umami auth fails (no 500)
- [x] Umami analytics script in layout still loads for page tracking


Made with [Cursor](https://cursor.com)