### PR TITLE
🔧 Upgrade unsplash

### DIFF
--- a/app/shots/page.tsx
+++ b/app/shots/page.tsx
@@ -23,7 +23,7 @@ export default async function Shots() {
           >
             <img
               src={shot.urls.regular}
-              alt={shot.alt_description || shot.description || ''}
+              alt={shot.description || ''}
               className="transition-transform duration-300 group-hover:scale-105"
             />
             <div className="from-background-neutral-faded/80 to-background-neutral-faded/80 text-body-small-subtle inset-shadow-foreground-neutral-default/10 absolute inset-x-0 bottom-0 flex translate-y-1/4 gap-2 bg-linear-to-b p-3 opacity-0 inset-shadow-xs transition-all duration-300 group-hover:translate-y-0 group-hover:opacity-100">

--- a/lib/unsplash.ts
+++ b/lib/unsplash.ts
@@ -4,82 +4,63 @@ export const unsplash = createApi({
   accessKey: process.env.UNSPLASH_ACCESS_KEY!,
 });
 
-interface Photo {
-  id: string;
-  urls: {
-    raw: string;
-    full: string;
-    regular: string;
-    small: string;
-    thumb: string;
-  };
-  alt_description: string | null;
-  description: string | null;
-  created_at: string;
-  updated_at: string;
-  width: number;
-  height: number;
-  color: string;
-  user: {
-    name: string;
-    username: string;
-  };
-  exif?: {
-    make: string | null;
-    model: string | null;
-    exposure_time: string | null;
-    aperture: string | null;
-    focal_length: string | null;
-    iso: number | null;
-  };
-}
-
 export async function fetchPhotos() {
   try {
-    const result = await unsplash.users.getPhotos({
-      username: process.env.UNSPLASH_USERNAME!,
+    const { data, error } = await unsplash.GET('/users/{username}/photos', {
+      params: {
+        path: { username: process.env.UNSPLASH_USERNAME! },
+      },
     });
 
-    if (!result.response) {
+    if (error || !data) {
       throw new Error('Failed to fetch photos');
     }
 
     const photos = await Promise.all(
-      result.response.results.map(async (p) => {
-        const photo = await unsplash.photos.get({ photoId: p.id });
-        return photo.response as Photo;
+      data.map(async (p) => {
+        const { data } = await unsplash.GET('/photos/{assetSlug}', {
+          params: {
+            path: { assetSlug: p.id },
+          },
+        });
+
+        return data;
       }),
     );
 
-    return photos;
+    return photos.filter((photo) => photo !== undefined);
   } catch (error) {
     console.error('Error fetching photos:', error);
     return [];
   }
 }
 
-export async function fetchPhotoStats(photoId: string) {
+export async function fetchStats(photoId: string) {
   try {
-    const result = await unsplash.photos.getStats({
-      photoId,
+    const { data } = await unsplash.GET('/photos/{assetSlug}/statistics', {
+      params: {
+        path: { assetSlug: photoId },
+      },
     });
 
-    return result.response;
+    return data ?? null;
   } catch (error) {
-    console.error('Error fetching photo stats:', error);
+    console.error('Error fetching stats:', error);
     return null;
   }
 }
 
-export async function fetchUserProfile() {
+export async function fetchUser() {
   try {
-    const result = await unsplash.users.get({
-      username: process.env.UNSPLASH_USERNAME!,
+    const { data } = await unsplash.GET('/users/{username}', {
+      params: {
+        path: { username: process.env.UNSPLASH_USERNAME! },
+      },
     });
 
-    return result.response;
+    return data ?? null;
   } catch (error) {
-    console.error('Error fetching user profile:', error);
+    console.error('Error fetching user:', error);
     return null;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "tailwindcss": "^4.1.4",
         "tsx": "^4.22.4",
         "typescript": "^6",
-        "unsplash-js": "^7.0.20"
+        "unsplash-js": "^8.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -7236,6 +7236,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-fetch": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.17.0.tgz",
+      "integrity": "sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.1.0"
+      }
+    },
+    "node_modules/openapi-typescript-helpers": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.1.0.tgz",
+      "integrity": "sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ora": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
@@ -9377,13 +9394,16 @@
       }
     },
     "node_modules/unsplash-js": {
-      "version": "7.0.20",
-      "resolved": "https://registry.npmjs.org/unsplash-js/-/unsplash-js-7.0.20.tgz",
-      "integrity": "sha512-0IzJGKbD6qHm0wg5sNndcCjhNDrtAr08/mySr9TGJ6biD7N03ZldidqXopkOvhAABaeFtRGYBrX1YkgMhKrFOQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/unsplash-js/-/unsplash-js-8.0.0.tgz",
+      "integrity": "sha512-WJQD4lIcwv66+hhSvcX4j1XsHl0jTEhEHXrChBJnMvMnmPV5nvLcX2hh50h7hMYlwGh5sRM/LUO++xUH0Y+s0Q==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "openapi-fetch": "^0.17.0"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=20"
       }
     },
     "node_modules/until-async": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "tailwindcss": "^4.1.4",
     "tsx": "^4.22.4",
     "typescript": "^6",
-    "unsplash-js": "^7.0.20"
+    "unsplash-js": "^8.0.0"
   }
 }


### PR DESCRIPTION
## Summary

- Upgrade `unsplash-js` from v7 to v8 and migrate the client to the typed OpenAPI `GET` API
- Remove the hand-written `Photo` interface in favor of SDK types
- Rename helpers to `fetchStats` and `fetchUser`
- Use `description` only for shot image alt text on `/shots`

## Testing

- [x] `/shots` loads and displays photos
- [x] Hover overlay shows EXIF data (make, model, aperture, focal length)
- [x] `npm run build` passes
- [x] No runtime errors when Unsplash env vars are set


Made with [Cursor](https://cursor.com)